### PR TITLE
Updated Cake.Core version from 0.17 to 0.26

### DIFF
--- a/src/Cake.FluentMigrator.Tests/Cake.FluentMigrator.Tests.csproj
+++ b/src/Cake.FluentMigrator.Tests/Cake.FluentMigrator.Tests.csproj
@@ -8,7 +8,7 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>Cake.FluentMigrator.Tests</RootNamespace>
     <AssemblyName>Cake.FluentMigrator.Tests</AssemblyName>
-    <TargetFrameworkVersion>v4.5.2</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.7.1</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <ProjectTypeGuids>{3AC096D0-A1C2-E12C-1390-A8335801FDAB};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
     <VisualStudioVersion Condition="'$(VisualStudioVersion)' == ''">10.0</VisualStudioVersion>
@@ -18,6 +18,7 @@
     <TestProjectType>UnitTest</TestProjectType>
     <NuGetPackageImportStamp>
     </NuGetPackageImportStamp>
+    <TargetFrameworkProfile />
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>
@@ -37,16 +38,21 @@
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="Cake.Core, Version=0.17.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\Cake.Core.0.17.0\lib\net45\Cake.Core.dll</HintPath>
-      <Private>True</Private>
+    <Reference Include="Cake.Core, Version=0.26.0.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\Cake.Core.0.26.0\lib\net46\Cake.Core.dll</HintPath>
     </Reference>
-    <Reference Include="Microsoft.VisualStudio.QualityTools.UnitTestFramework, Version=10.1.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL" />
+    <Reference Include="Microsoft.CSharp" />
+    <Reference Include="Microsoft.VisualStudio.QualityTools.UnitTestFramework, Version=10.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <Private>False</Private>
+    </Reference>
     <Reference Include="NSubstitute, Version=1.10.0.0, Culture=neutral, PublicKeyToken=92dd2e9066daa5ca, processorArchitecture=MSIL">
       <HintPath>..\packages\NSubstitute.1.10.0.0\lib\net45\NSubstitute.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="System" />
+    <Reference Include="System.Data" />
+    <Reference Include="System.Xml" />
+    <Reference Include="System.Xml.Linq" />
   </ItemGroup>
   <ItemGroup>
     <Compile Include="..\SolutionInfo.cs">

--- a/src/Cake.FluentMigrator.Tests/FluentMigratorToolResolverTests.cs
+++ b/src/Cake.FluentMigrator.Tests/FluentMigratorToolResolverTests.cs
@@ -10,21 +10,6 @@ namespace Cake.FluentMigrator.Tests
     public class FluentMigratorToolResolverTests
     {
         [TestMethod]
-        public void ResolvePath_AnyCPU_40()
-        {
-            var fixture = new ToolResolverFixture(PlatformFamily.Windows, true, Version.Parse("4.5.2"));
-            var rootPath = new DirectoryPath("c:/tests/tools/FluentMigrator.Tools/tools/AnyCPU/40");
-            fixture.ToolLocator.Resolve("AnyCPU/40/Migrate.exe").Returns(rootPath.CombineWithFilePath("Migrate.exe"));
-            fixture.FileSystem.Exist(Arg.Any<FilePath>()).Returns(true);
-
-            var toolResolver = new FluentMigratorToolResolver(fixture.FileSystem, fixture.Environment, fixture.ToolLocator);
-
-            var toolPath = toolResolver.ResolvePath();
-
-            Assert.AreEqual(rootPath.CombineWithFilePath("Migrate.exe").FullPath, toolPath.FullPath);
-        }
-
-        [TestMethod]
         public void ResolvePath_AnyCPU_35()
         {
             var fixture = new ToolResolverFixture(PlatformFamily.Windows, true, Version.Parse("3.5.0"));
@@ -40,14 +25,25 @@ namespace Cake.FluentMigrator.Tests
         }
 
         [TestMethod]
-        public void ResolvePath_x86_40()
+        public void ResolvePath_AnyCPU_40()
         {
-            var fixture = new ToolResolverFixture(PlatformFamily.Windows, false, Version.Parse("4.5.2"));
-            var rootPath = new DirectoryPath("c:/tests/tools/FluentMigrator.Tools/tools/x86/40");
-            fixture.ToolLocator.Resolve("x86/40/Migrate.exe").Returns(rootPath.CombineWithFilePath("Migrate.exe"));
-            fixture.FileSystem.Exist(Arg.Any<FilePath>()).Returns(true);
+            var fixture = new ToolResolverFixture(PlatformFamily.Windows, true, Version.Parse("4.5.2"));
+            var rootPath = new DirectoryPath("c:/tests/tools/FluentMigrator.Tools/tools/AnyCPU/40");
 
-            var toolResolver = new FluentMigratorToolResolver(fixture.FileSystem, fixture.Environment, fixture.ToolLocator);
+            fixture
+                .ToolLocator
+                .Resolve("AnyCPU/40/Migrate.exe")
+                .Returns(rootPath.CombineWithFilePath("Migrate.exe"));
+
+            fixture
+                .FileSystem
+                .Exist(Arg.Any<FilePath>())
+                .Returns(true);
+
+            var toolResolver = new FluentMigratorToolResolver(
+                fixture.FileSystem,
+                fixture.Environment,
+                fixture.ToolLocator);
 
             var toolPath = toolResolver.ResolvePath();
 
@@ -60,6 +56,21 @@ namespace Cake.FluentMigrator.Tests
             var fixture = new ToolResolverFixture(PlatformFamily.Windows, false, Version.Parse("3.5.0"));
             var rootPath = new DirectoryPath("c:/tests/tools/FluentMigrator.Tools/tools/x86/35");
             fixture.ToolLocator.Resolve("x86/35/Migrate.exe").Returns(rootPath.CombineWithFilePath("Migrate.exe"));
+            fixture.FileSystem.Exist(Arg.Any<FilePath>()).Returns(true);
+
+            var toolResolver = new FluentMigratorToolResolver(fixture.FileSystem, fixture.Environment, fixture.ToolLocator);
+
+            var toolPath = toolResolver.ResolvePath();
+
+            Assert.AreEqual(rootPath.CombineWithFilePath("Migrate.exe").FullPath, toolPath.FullPath);
+        }
+
+        [TestMethod]
+        public void ResolvePath_x86_40()
+        {
+            var fixture = new ToolResolverFixture(PlatformFamily.Windows, false, Version.Parse("4.5.2"));
+            var rootPath = new DirectoryPath("c:/tests/tools/FluentMigrator.Tools/tools/x86/40");
+            fixture.ToolLocator.Resolve("x86/40/Migrate.exe").Returns(rootPath.CombineWithFilePath("Migrate.exe"));
             fixture.FileSystem.Exist(Arg.Any<FilePath>()).Returns(true);
 
             var toolResolver = new FluentMigratorToolResolver(fixture.FileSystem, fixture.Environment, fixture.ToolLocator);

--- a/src/Cake.FluentMigrator.Tests/ToolResolverFixture.cs
+++ b/src/Cake.FluentMigrator.Tests/ToolResolverFixture.cs
@@ -7,14 +7,8 @@ using NSubstitute;
 
 namespace Cake.FluentMigrator.Tests
 {
-    class ToolResolverFixture
+    internal class ToolResolverFixture
     {
-        public ICakeEnvironment Environment { get; set; }
-
-        public IFileSystem FileSystem { get; set; }
-
-        public IToolLocator ToolLocator { get; set; }
-
         public ToolResolverFixture(PlatformFamily family, bool is64Bit, Version frameworkVersion)
         {
             Environment = Substitute.For<ICakeEnvironment>();
@@ -29,12 +23,18 @@ namespace Cake.FluentMigrator.Tests
             Environment.Runtime.Returns(info =>
             {
                 var runtime = Substitute.For<ICakeRuntime>();
-                runtime.TargetFramework.Returns(callInfo => new FrameworkName(".Net 4.5.2", frameworkVersion));
+                runtime.BuiltFramework.Returns(callInfo => new FrameworkName(".Net 4.5.2", frameworkVersion));
                 return runtime;
             });
 
             FileSystem = Substitute.For<IFileSystem>();
             ToolLocator = Substitute.For<IToolLocator>();
         }
+
+        public ICakeEnvironment Environment { get; set; }
+
+        public IFileSystem FileSystem { get; set; }
+
+        public IToolLocator ToolLocator { get; set; }
     }
 }

--- a/src/Cake.FluentMigrator.Tests/packages.config
+++ b/src/Cake.FluentMigrator.Tests/packages.config
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Cake.Core" version="0.17.0" targetFramework="net452" />
+  <package id="Cake.Core" version="0.26.0" targetFramework="net471" />
   <package id="NSubstitute" version="1.10.0.0" targetFramework="net452" />
 </packages>

--- a/src/Cake.FluentMigrator.sln
+++ b/src/Cake.FluentMigrator.sln
@@ -1,7 +1,7 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
-# Visual Studio 14
-VisualStudioVersion = 14.0.25420.1
+# Visual Studio 15
+VisualStudioVersion = 15.0.27130.2036
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Cake.FluentMigrator", "Cake.FluentMigrator\Cake.FluentMigrator.csproj", "{2803512B-59C0-4A53-91E5-4D1C40949A63}"
 EndProject
@@ -24,5 +24,8 @@ Global
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
+	EndGlobalSection
+	GlobalSection(ExtensibilityGlobals) = postSolution
+		SolutionGuid = {686E00D5-E463-46EA-BA22-FFE17420B435}
 	EndGlobalSection
 EndGlobal

--- a/src/Cake.FluentMigrator/Cake.FluentMigrator.csproj
+++ b/src/Cake.FluentMigrator/Cake.FluentMigrator.csproj
@@ -9,12 +9,13 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>Cake.FluentMigrator</RootNamespace>
     <AssemblyName>Cake.FluentMigrator</AssemblyName>
-    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.7.1</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <SolutionDir Condition="$(SolutionDir) == '' Or $(SolutionDir) == '*Undefined*'">..\</SolutionDir>
     <RestorePackages>true</RestorePackages>
     <NuGetPackageImportStamp>
     </NuGetPackageImportStamp>
+    <TargetFrameworkProfile />
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>
@@ -30,7 +31,7 @@
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
     <DebugType>pdbonly</DebugType>
     <Optimize>true</Optimize>
-    <OutputPath>bin\Release\</OutputPath>
+    <OutputPath>..\..\..\Farfetch-PoCs\FF.FV.Migrations\tools\Addins\Cake.FluentMigrator.0.3.0\lib\net45\</OutputPath>
     <DefineConstants>TRACE</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
@@ -38,9 +39,8 @@
     <CodeAnalysisRuleSet>Cake.FluentMigrator.ruleset</CodeAnalysisRuleSet>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="Cake.Core, Version=0.17.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\Cake.Core.0.17.0\lib\net45\Cake.Core.dll</HintPath>
-      <Private>True</Private>
+    <Reference Include="Cake.Core, Version=0.26.0.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\Cake.Core.0.26.0\lib\net46\Cake.Core.dll</HintPath>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />

--- a/src/Cake.FluentMigrator/FluentMigratorRunner.cs
+++ b/src/Cake.FluentMigrator/FluentMigratorRunner.cs
@@ -12,21 +12,61 @@ namespace Cake.FluentMigrator
     /// </summary>
     public class FluentMigratorRunner : Tool<FluentMigratorSettings>
     {
-
         private readonly IFluentMigratorToolResolver _resolver;
 
         /// <summary>
-        /// Initializes a new instance of the <see cref="FluentMigratorRunner" /> class.
+        /// Initializes a new instance of the <see cref="FluentMigratorRunner"/> class.
         /// </summary>
         /// <param name="fileSystem">The file system.</param>
         /// <param name="environment">The environment.</param>
         /// <param name="processRunner">The process runner.</param>
         /// <param name="toolLocator">The tool locator.</param>
         /// <param name="resolver">The tool resolver</param>
-        public FluentMigratorRunner(IFileSystem fileSystem, ICakeEnvironment environment, IProcessRunner processRunner, IToolLocator toolLocator, IFluentMigratorToolResolver resolver)
+        public FluentMigratorRunner(IFileSystem fileSystem, ICakeEnvironment environment,
+            IProcessRunner processRunner, IToolLocator toolLocator, IFluentMigratorToolResolver resolver)
             : base(fileSystem, environment, processRunner, toolLocator)
         {
             _resolver = resolver;
+        }
+
+        /// <summary>
+        /// Executes FluentMigrator using the provided settings.
+        /// </summary>
+        /// <param name="settings">The settings.</param>
+        public void Run(FluentMigratorSettings settings)
+        {
+            if (settings == null)
+            {
+                throw new ArgumentNullException(nameof(settings));
+            }
+
+            Run(settings, GetArguments(settings));
+        }
+
+        /// <summary>
+        /// Gets alternative file paths which the tool may exist in
+        /// </summary>
+        /// <param name="settings">The settings.</param>
+        /// <returns>The default tool path.</returns>
+        protected override IEnumerable<FilePath> GetAlternativeToolPaths(FluentMigratorSettings settings)
+        {
+            return new[] { _resolver.ResolvePath() };
+        }
+
+        /// <summary>
+        /// Gets the possible names of the tool executable.
+        /// </summary>
+        /// <returns>The tool executable name.</returns>
+        protected override IEnumerable<string> GetToolExecutableNames()
+        {
+            return new[]
+            {
+                "AnyCPU/40/Migrate.exe",
+                "AnyCPU/35/Migrate.exe",
+
+                "x86/40/Migrate.exe",
+                "x86/35/Migrate.exe"
+            };
         }
 
         /// <summary>
@@ -38,27 +78,25 @@ namespace Cake.FluentMigrator
             return "FluentMigrator";
         }
 
-        /// <summary>
-        /// Gets the possible names of the tool executable.
-        /// </summary>
-        /// <returns>
-        /// The tool executable name.
-        /// </returns>
-        protected override IEnumerable<string> GetToolExecutableNames()
+        private static void AddArgument(ProcessArgumentBuilder builder, string @switch, string value)
         {
-            return new[] { "AnyCPU/40/Migrate.exe", "AnyCPU/35/Migrate.exe", "x86/40/Migrate.exe", "x86/35/Migrate.exe" };
+            if (String.IsNullOrEmpty(value))
+            {
+                return;
+            }
+
+            builder.Append(@switch);
+            builder.AppendQuoted(value);
         }
 
-        /// <summary>
-        /// Gets alternative file paths which the tool may exist in
-        /// </summary>
-        /// <param name="settings">The settings.</param>
-        /// <returns>
-        /// The default tool path.
-        /// </returns>
-        protected override IEnumerable<FilePath> GetAlternativeToolPaths(FluentMigratorSettings settings)
+        private static void AddArgument(ProcessArgumentBuilder builder, string @switch, bool value)
         {
-            return new[] { _resolver.ResolvePath() };
+            if (!value)
+            {
+                return;
+            }
+
+            builder.Append(@switch);
         }
 
         private ProcessArgumentBuilder GetArguments(FluentMigratorSettings settings)
@@ -111,41 +149,6 @@ namespace Cake.FluentMigrator
             }
 
             return builder;
-        }
-
-        private static void AddArgument(ProcessArgumentBuilder builder, string @switch, string value)
-        {
-            if (String.IsNullOrEmpty(value))
-            {
-                return;
-            }
-
-            builder.Append(@switch);
-            builder.AppendQuoted(value);
-        }
-
-        private static void AddArgument(ProcessArgumentBuilder builder, string @switch, bool value)
-        {
-            if (!value)
-            {
-                return;
-            }
-
-            builder.Append(@switch);
-        }
-
-        /// <summary>
-        /// Executes FluentMigrator using the provided settings.
-        /// </summary>
-        /// <param name="settings">The settings.</param>
-        public void Run(FluentMigratorSettings settings)
-        {
-            if (settings == null)
-            {
-                throw new ArgumentNullException(nameof(settings));
-            }
-
-            Run(settings, GetArguments(settings));
         }
     }
 }

--- a/src/Cake.FluentMigrator/FluentMigratorToolResolver.cs
+++ b/src/Cake.FluentMigrator/FluentMigratorToolResolver.cs
@@ -9,12 +9,12 @@ namespace Cake.FluentMigrator
     /// </summary>
     public class FluentMigratorToolResolver : IFluentMigratorToolResolver
     {
-        private readonly IFileSystem _fileSystem;
         private readonly ICakeEnvironment _environment;
+        private readonly IFileSystem _fileSystem;
         private readonly IToolLocator _toolLocator;
 
         /// <summary>
-        /// Initializes a new instance of the <see cref="FluentMigratorToolResolver" /> class.
+        /// Initializes a new instance of the <see cref="FluentMigratorToolResolver"/> class.
         /// </summary>
         /// <param name="fileSystem">The file system.</param>
         /// <param name="environment">The environment.</param>
@@ -33,7 +33,7 @@ namespace Cake.FluentMigrator
         public FilePath ResolvePath()
         {
             var arch = _environment.Platform.Is64Bit ? "AnyCPU" : "x86";
-            var frameworkVersion = _environment.Runtime.TargetFramework.Version.Major >= 4 ? "40" : "35";
+            var frameworkVersion = _environment.Runtime.BuiltFramework.Version.Major >= 4 ? "40" : "35";
             var toolPath = _toolLocator.Resolve($"{arch}/{frameworkVersion}/Migrate.exe");
 
             if (toolPath == null || !_fileSystem.Exist(toolPath))

--- a/src/Cake.FluentMigrator/packages.config
+++ b/src/Cake.FluentMigrator/packages.config
@@ -1,4 +1,4 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Cake.Core" version="0.17.0" targetFramework="net45" />
+  <package id="Cake.Core" version="0.26.0" targetFramework="net471" />
 </packages>


### PR DESCRIPTION
In this PR I could update the Cake.Core version for the Cake.FluentMigrator package and I change the Target framework to support 4.7.1

@gep13 please take a look on these changes. They're very importante to follow the changes that there are happening into the community!